### PR TITLE
Apply FinTech themed styling

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,3 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 60">
-  <text x="0" y="45" font-size="45" font-family="Arial, sans-serif" fill="black">FlintN</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 60">
+  <text x="0" y="45" font-size="45" font-family="Poppins, Arial, sans-serif" fill="#0dbb8e">FinTech</text>
+  <text x="130" y="45" font-size="45" font-family="Poppins, Arial, sans-serif" fill="#ffffff">Radar</text>
 </svg>

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,4 +1,3 @@
-import { Roboto } from "next/font/google";
 import { FC, ReactNode } from "react";
 
 import styles from "./Layout.module.css";
@@ -7,8 +6,6 @@ import { Footer } from "@/components/Footer/Footer";
 import { Logo } from "@/components/Logo/Logo";
 import { Navigation } from "@/components/Navigation/Navigation";
 import { cn } from "@/lib/utils";
-
-const font = Roboto({ weight: ["400", "700"], subsets: ["latin"] });
 
 export type LayoutClass = "default" | "full";
 
@@ -22,10 +19,7 @@ export const Layout: FC<LayoutProps> = ({
   layoutClass = "default",
 }) => {
   return (
-    <div
-      id="layout"
-      className={cn(styles.layout, font.className, styles[layoutClass])}
-    >
+    <div id="layout" className={cn(styles.layout, styles[layoutClass])}>
       <header className={cn(styles.container, styles.header)}>
         <Logo />
         <Navigation />

--- a/src/styles/_globals.css
+++ b/src/styles/_globals.css
@@ -1,3 +1,5 @@
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap");
+
 :root {
   --max-width: 1200px;
   --border-radius: 12px;
@@ -6,13 +8,13 @@
     "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
     "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
 
-  --foreground: #fff;
-  --background: #173d7a;
-  --content: #fff;
-  --text: #575757;
-  --link: #029df7;
-  --highlight: #029df7;
-  --border: rgba(255, 255, 255, 0.1);
+  --foreground: #ffffff;
+  --background: #0d1b2a;
+  --content: #ffffff;
+  --text: #333333;
+  --link: #0dbb8e;
+  --highlight: #0dbb8e;
+  --border: rgba(255, 255, 255, 0.2);
   --tag: rgba(255, 255, 255, 0.1);
 }
 
@@ -34,6 +36,7 @@ body {
 body {
   color: var(--foreground);
   background: var(--background);
+  font-family: "Poppins", Arial, sans-serif;
   font-weight: 400;
   line-height: 1.3em;
 }


### PR DESCRIPTION
## Summary
- restyle default colors for a FinTech look
- load Poppins via CSS and drop `next/font` usage
- update global font rules
- refresh project logo

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840c18670c0832aa4ed5a83ea51fa79