### PR TITLE
feat: update branding to N-iX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# FlintN Technology Radar
+# N-iX Technology Radar
 
-A static site generator for FlintN Technology Radar
+A static site generator for N-iX Technology Radar
 
-![Screenshot of the FlintN Technology Radar](./docs/assets/screenshot-techradar.png)
+![Screenshot of the N-iX Technology Radar](./docs/assets/screenshot-techradar.png)
 
-## Looking for the FlintN Tech Radar content?
+## Looking for the N-iX Tech Radar content?
 
 - The repository is now found here: https://github.com/AOEpeople/techradar
-- The FlintN Tech radar is deployed here: https://www.flintn.com/techradar/index.html
+- The N-iX Tech radar is deployed here: https://www.n-ix.com/techradar/index.html
 
 ## ✨ Version 4.0.0
 
-Version 4.0.0 is a complete rewrite of the FlintN Technology Radar. It is now based
+Version 4.0.0 is a complete rewrite of the N-iX Technology Radar. It is now based
 on [Next.js](https://nextjs.org/) to provide enhanced static site generation. The visualization has
 been rewritten without the need for the D3 dependency. New features include a fuzzy search based on
 Fuse.js, non-overlapping blips on the radar, and a reworked tag filter on the homepage.
@@ -41,7 +41,7 @@ file like the following and adapt to your needs:
 
 ```json
 {
-  "name": "flintn-techradar",
+    "name": "nix-techradar",
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {
@@ -49,7 +49,7 @@ file like the following and adapt to your needs:
     "serve": "techradar serve"
   },
   "dependencies": {
-    "flintn_technology_radar": "^4"
+      "n-ix_technology_radar": "^4"
   }
 }
 ```
@@ -75,7 +75,7 @@ Open the `config.json` file and configure the radar to your needs.
 | Attribute   | Description                                                                                                                    |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | basePath    | Set if hosting under a sub-path, otherwise set it to `/`. Default is `/techradar`                                              |
-| baseUrl     | Set to the full URL, where the radar will be hosted. Will be used for sitemap.xml. `https://www.flintn.com/techradar`          |
+| baseUrl     | Set to the full URL, where the radar will be hosted. Will be used for sitemap.xml. `https://www.n-ix.com/techradar`          |
 | logoFile    | (optional) Filepath in public folder. Default is `logo.svg`                                                                    |
 | jsFile      | (optional) Filepath in public folder or URL to enable include of custom script                                                 |
 | toggles     | (optional) Modify the behaviour and contents of the radar. See config below.                                                   |

--- a/data/about.md
+++ b/data/about.md
@@ -5,7 +5,7 @@
 Edit this file to your needs to provide an introduction to the technology radar. Explain the purpose
 of the radar and how it is created. This is a good place to explain the quadrants and rings, too.
 
-### Contributing to the FlintN Technology Radar
+### Contributing to the N-iX Technology Radar
 
-Contributions and source code of the FlintN Tech Radar are on
-GitHub: [FlintN Tech Radar on GitHub](https://github.com/AOEpeople/aoe_technology_radar)
+Contributions and source code of the N-iX Tech Radar are on
+GitHub: [N-iX Tech Radar on GitHub](https://github.com/AOEpeople/aoe_technology_radar)

--- a/data/config.default.json
+++ b/data/config.default.json
@@ -13,14 +13,14 @@
   },
   "sections": ["radar", "tags", "list"],
   "colors": {
-    "foreground": "#fcf2e6",
-    "background": "#113521",
-    "highlight": "#d4a373",
+    "foreground": "#ffffff",
+    "background": "#ff8c00",
+    "highlight": "#ff8800",
     "content": "#fff",
-    "text": "#575757",
-    "link": "#bc6c25",
-    "border": "rgba(255, 255, 255, 0.1)",
-    "tag": "rgba(255, 255, 255, 0.1)"
+    "text": "#000000",
+    "link": "#ff8800",
+    "border": "rgba(0, 0, 0, 0.1)",
+    "tag": "rgba(0, 0, 0, 0.1)"
   },
   "quadrants": [
     {
@@ -105,34 +105,34 @@
   },
   "social": [
     {
-      "href": "https://twitter.com/flintn",
+      "href": "https://twitter.com/n_ix",
       "icon": "x"
     },
     {
-      "href": "https://www.linkedin.com/company/flintn",
+      "href": "https://www.linkedin.com/company/n-ix",
       "icon": "linkedIn"
     },
     {
-      "href": "https://www.xing.com/company/flintn",
+      "href": "https://www.xing.com/company/n-ix",
       "icon": "xing"
     },
     {
-      "href": "https://github.com/flintn",
+      "href": "https://github.com/n-ix",
       "icon": "github"
     }
   ],
-  "imprint": "https://www.flintn.com/en/imprint.html",
+  "imprint": "https://www.n-ix.com/imprint",
   "labels": {
-    "title": "Technology Radar",
+    "title": "N-iX Technology Radar",
     "imprint": "Legal Information",
     "quadrant": "Quadrant",
     "quadrantOverview": "Quadrant Overview",
     "zoomIn": "Zoom in",
     "filterByTag": "Filter by Tag",
-    "footer": "The technology radar is a project by FlintN. Feel free to build your own radar based on the open source project.",
+    "footer": "The technology radar is a project by N-iX. Feel free to build your own radar based on the open source project.",
     "notUpdated": "This item was not updated in last three versions of the Radar. Should it have appeared in one of the more recent editions, there is a good chance it remains pertinent. However, if the item dates back further, its relevance may have diminished and our current evaluation could vary. Regrettably, our capacity to consistently revisit items from past Radar editions is limited.",
     "notFound": "404 - Page not found",
-    "pageAbout": "How to use FlintN Technology Radar?",
+    "pageAbout": "How to use N-iX Technology Radar?",
     "pageOverview": "Technologies Overview",
     "pageSearch": "Search",
     "searchPlaceholder": "What are you looking for?",

--- a/src/components/Badge/Badge.module.css
+++ b/src/components/Badge/Badge.module.css
@@ -42,9 +42,9 @@
     border: 1px solid var(--foreground);
     background: transparent;
 
-    &.selected {
-      color: var(--background);
-      background: var(--foreground);
+      &.selected {
+        color: var(--text);
+        background: var(--foreground);
+      }
     }
   }
-}

--- a/src/components/ItemList/ItemList.module.css
+++ b/src/components/ItemList/ItemList.module.css
@@ -41,12 +41,12 @@
     opacity: 0.65;
   }
 
-  &:hover,
-  &.isActive {
-    background: var(--foreground);
-    color: var(--background);
-    opacity: 1;
-  }
+    &:hover,
+    &.isActive {
+      background: var(--foreground);
+      color: var(--text);
+      opacity: 1;
+    }
 }
 
 .isSmall {

--- a/src/components/SocialLinks/SocialLinks.module.css
+++ b/src/components/SocialLinks/SocialLinks.module.css
@@ -7,11 +7,11 @@
   padding: 0;
 }
 
-.icon {
-  fill: var(--background);
-  width: 16px;
-  height: 16px;
-}
+  .icon {
+    fill: var(--text);
+    width: 16px;
+    height: 16px;
+  }
 
 .link {
   display: block;

--- a/src/components/Tags/Tags.module.css
+++ b/src/components/Tags/Tags.module.css
@@ -22,12 +22,12 @@
   text-decoration: none;
   transition: all 150ms ease-in-out;
 
-  &:hover,
-  &:focus,
-  &.active {
-    background: var(--foreground);
-    color: var(--background);
-  }
+    &:hover,
+    &:focus,
+    &.active {
+      background: var(--foreground);
+      color: var(--text);
+    }
 
   &.active {
     .icon {

--- a/src/styles/_globals.css
+++ b/src/styles/_globals.css
@@ -9,13 +9,13 @@
     "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
 
   --foreground: #ffffff;
-  --background: #0d1b2a;
+  --background: #ff8c00;
   --content: #ffffff;
-  --text: #333333;
-  --link: #0dbb8e;
-  --highlight: #0dbb8e;
-  --border: rgba(255, 255, 255, 0.2);
-  --tag: rgba(255, 255, 255, 0.1);
+  --text: #000000;
+  --link: #ff8800;
+  --highlight: #ff8800;
+  --border: rgba(0, 0, 0, 0.1);
+  --tag: rgba(0, 0, 0, 0.1);
 }
 
 * {
@@ -34,8 +34,8 @@ body {
 }
 
 body {
-  color: var(--foreground);
-  background: var(--background);
+  color: var(--text);
+  background: linear-gradient(135deg, #ffbb33 0%, #ff8800 100%);
   font-family: "Poppins", Arial, sans-serif;
   font-weight: 400;
   line-height: 1.3em;
@@ -75,6 +75,7 @@ h4 {
 
 h1 {
   font-size: 37px;
+  color: var(--foreground);
 }
 
 h2 {
@@ -111,7 +112,7 @@ code {
 
 input {
   background: var(--foreground);
-  color: var(--background);
+  color: var(--text);
   border: 1px solid transparent;
   padding: 10px 12px;
   border-radius: 3px;


### PR DESCRIPTION
## Summary
- rename Tech Radar references from FlintN to N-iX
- adopt orange gradient theme with white H1 and black body text
- adjust styles to use new text color variable

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68957fb93520832abb1c0d2376c56cad